### PR TITLE
Reduce the explicitness of the requirements.txt file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 bs4>=0.0.1
 rainbow-logging-handler>=2.2.2
-requests>=2.18.1
-urllib3>=1.21.1
-boto3>=1.4.4
+requests>=2.10.0
+urllib3
+boto3>=1.4.0
 
 # TODO: Explain
 aws_role_credentials==0.6.3


### PR DESCRIPTION
The super-up-to-date requirements of the libraries are problematic if
you're using a shared virtualenv with other stuff. Its not really
necessary, so lets just reduce the version numbers.