### PR TITLE
Fix issue with log msg

### DIFF
--- a/nd_okta_auth/okta.py
+++ b/nd_okta_auth/okta.py
@@ -263,7 +263,7 @@ class OktaSaml(Okta):
         try:
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            log.error('Unknown error: {msg}'.format(str(e.response.__dict__)))
+            log.error('Unknown error: {msg}'.format(msg=str(e.response.__dict__)))
             raise UnknownError()
 
         return self.assertion(resp.text.decode('utf8'))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/slava/src/dotfiles/.venv/bin/nd_okta_auth", line 11, in <module>
    load_entry_point('nd-okta-auth==0.0.1', 'console_scripts', 'nd_okta_auth')()
  File "/Users/slava/src/dotfiles/.venv/lib/python2.7/site-packages/nd_okta_auth/main.py", line 182, in entry_point
    raise SystemExit(main(sys.argv))
  File "/Users/slava/src/dotfiles/.venv/lib/python2.7/site-packages/nd_okta_auth/main.py", line 159, in main
    apptype='amazon_aws')
  File "/Users/slava/src/dotfiles/.venv/lib/python2.7/site-packages/nd_okta_auth/okta.py", line 266, in get_assertion
    log.error('Unknown error: {msg}'.format(str(e.response.__dict__)))
KeyError: 'msg'
```