### PR TITLE
Write to both default profile and specified profile.

### DIFF
--- a/nd_okta_auth/aws.py
+++ b/nd_okta_auth/aws.py
@@ -179,11 +179,12 @@ class Session(object):
 
     def _write(self):
         '''Writes out our secrets to the Credentials object'''
-        self.writer.add_profile(
-            name=self.profile,
-            region=self.region,
-            access_key=self.aws_access_key_id,
-            secret_key=self.aws_secret_access_key,
-            session_token=self.session_token)
+        for profile in ['default', self.profile]:
+            self.writer.add_profile(
+                name=profile,
+                region=self.region,
+                access_key=self.aws_access_key_id,
+                secret_key=self.aws_secret_access_key,
+                session_token=self.session_token)
         log.info('Session expires at {time}'.format(
             time=self.expiration))

--- a/nd_okta_auth/main.py
+++ b/nd_okta_auth/main.py
@@ -159,7 +159,7 @@ def main(argv):
         # still valid. If it is, sleep a bit and skip to the next execution of
         # the loop.
         if session and session.is_valid:
-            log.debug('Credentials are still valid, sleepingt')
+            log.debug('Credentials are still valid, sleeping')
             time.sleep(15)
             continue
 


### PR DESCRIPTION
This will allow any aws cli commands to work off the of last aws auth, rather than needing the profile explicitly specified.