### PR TITLE
Allow KeyboardInterrupt during waiting for push notification verification.

### DIFF
--- a/nd_okta_auth/main.py
+++ b/nd_okta_auth/main.py
@@ -147,7 +147,7 @@ def main(argv):
         log.warning('MFA Requirement Detected - Enter your passcode here')
         verified = False
         while not verified:
-            passcode = getpass.getpass('MFA Passcode: ')
+            passcode = raw_input('MFA Passcode: ')
             verified = okta_client.validate_mfa(e.fid, e.state_token, passcode)
 
     # Once we're authenticated with an OktaSaml client object, we can use that

--- a/nd_okta_auth/okta.py
+++ b/nd_okta_auth/okta.py
@@ -230,9 +230,13 @@ class Okta(object):
         if status == 'MFA_REQUIRED' or status == 'MFA_CHALLENGE':
             for factor in ret['_embedded']['factors']:
                 if factor['factorType'] == 'push':
-                    if self.okta_verify_with_push(factor['id'],
-                                                  ret['stateToken']):
-                        return
+                    try:
+                        if self.okta_verify_with_push(factor['id'],
+                                                      ret['stateToken']):
+                            return
+                    except KeyboardInterrupt:
+                        # Allow users to use MFA Passcode by breaking out of waiting for the push.
+                        break
 
             for factor in ret['_embedded']['factors']:
                 if factor['factorType'] == 'token:software:totp':


### PR DESCRIPTION
This is useful as sometimes Okta Verify is delayed.

Also: Change passcode input to be raw_input instead of getpass.

This isn't a secret in the same way, and it's helpful to be able to see what you're typing here.