### PR TITLE
Fix issue #10; AWS credfile permissions

### DIFF
--- a/nd_okta_auth/aws.py
+++ b/nd_okta_auth/aws.py
@@ -56,6 +56,7 @@ class Credentials(object):
 
         [(config.set(name, k, v)) for k, v in profile.items()]
         with open(self.filename, 'w+') as configfile:
+            os.chmod(self.filename, 0o600)
             config.write(configfile)
 
     def add_profile(self, name, region, access_key, secret_key, session_token):

--- a/nd_okta_auth/test/aws_test.py
+++ b/nd_okta_auth/test/aws_test.py
@@ -7,9 +7,10 @@ from nd_okta_auth import aws
 
 class TestCredentials(unittest.TestCase):
 
+    @mock.patch('nd_okta_auth.aws.os.chmod')
     @mock.patch('configparser.ConfigParser')
     @mock.patch('nd_okta_auth.aws.open')
-    def test_add_profile(self, open_mock, parser_mock):
+    def test_add_profile(self, open_mock, parser_mock, chmod_mock):
         fake_parser = mock.MagicMock(name='config_parser')
         parser_mock.return_value = fake_parser
 
@@ -35,11 +36,13 @@ class TestCredentials(unittest.TestCase):
             mock.call.set(u'TestProfile', u'aws_access_key_id', u'key')
         ])
 
+    @mock.patch('nd_okta_auth.aws.os.chmod')
     @mock.patch('configparser.ConfigParser')
     @mock.patch('nd_okta_auth.aws.open')
     def test_add_profile_missing_file_creates_new(self,
                                                   open_mock,
-                                                  parser_mock):
+                                                  parser_mock,
+                                                  chmod_mock):
         fake_parser = mock.MagicMock(name='config_parser')
         parser_mock.return_value = fake_parser
 
@@ -59,6 +62,11 @@ class TestCredentials(unittest.TestCase):
         open_mock.assert_has_calls([
             mock.call('/test', 'r'),
             mock.call('/test', 'w+')
+        ])
+
+        # Verify we're setting the file permissions as 0600 for safety
+        chmod_mock.assert_has_calls([
+            mock.call('/test', 0o600)
         ])
 
 


### PR DESCRIPTION
This PR fixes issue #10 and sets the AWS credfile to 0600 rather than the default 0744 to prevent other users on the system from being able to read the file.