### PR TITLE
Add Python 3.5+ support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            virtualenv venv
+            python -m venv venv || virtualenv venv
             . venv/bin/activate
             pip install -r requirements.txt
             pip install -r requirements.test.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 version: 2
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test-3.6
+      - test-3.5
+      - test-2.7
 jobs:
-  build:
+  test-2.7: &test-template
     docker:
       - image: circleci/python:2.7
     steps:
@@ -27,3 +34,11 @@ jobs:
           command: |
             . venv/bin/activate
             python setup.py pyflakes
+  test-3.5:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.5
+  test-3.6:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.6

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 MANIFEST
 README
 nd_okta_auth.egg-info
+.idea/
+build/

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ environment is quick and easy.
     $ virtualenv .venv
     $ source .venv/bin/activate
     $ pip install -r requirements.txt
+    
+## Python Versions
+
+Python 2.7.1+ and Python 3.5.0+ are supported
 
 ## Running Tests
 

--- a/nd_okta_auth/aws.py
+++ b/nd_okta_auth/aws.py
@@ -12,13 +12,13 @@ Thought Works Inc.
 '''
 
 from __future__ import unicode_literals
+from builtins import str
 import configparser
 import datetime
 import logging
 import os
 from os.path import expanduser
 import xml
-from builtins import str
 
 import boto3
 from nd_okta_auth.aws_saml import SamlAssertion

--- a/nd_okta_auth/aws.py
+++ b/nd_okta_auth/aws.py
@@ -11,16 +11,17 @@ modified from the original code, but thanks a ton to the original writers at
 Thought Works Inc.
 '''
 
-import boto3
+from __future__ import unicode_literals
 import configparser
 import datetime
 import logging
 import os
-import xml
-
 from os.path import expanduser
+import xml
+from builtins import str
 
-from aws_role_credentials import models
+import boto3
+from nd_okta_auth.aws_saml import SamlAssertion
 
 log = logging.getLogger(__name__)
 
@@ -69,15 +70,15 @@ class Credentials(object):
             secret_key: The AWS_SECRET_ACCESS_KEY
             session_token: The AWS_SESSION_TOKEN
         '''
-        name = unicode(name)
+        name = str(name)
         self._add_profile(
             name,
-            {u'output': u'json',
-             u'region': unicode(region),
-             u'aws_access_key_id': unicode(access_key),
-             u'aws_secret_access_key': unicode(secret_key),
-             u'aws_security_token': unicode(session_token),
-             u'aws_session_token': unicode(session_token)
+            {'output': 'json',
+             'region': str(region),
+             'aws_access_key_id': str(access_key),
+             'aws_secret_access_key': str(secret_key),
+             'aws_security_token': str(session_token),
+             'aws_session_token': str(session_token)
              })
 
         log.info('Wrote profile "{name}" to {file}'.format(
@@ -117,7 +118,7 @@ class Session(object):
         self.profile = profile
         self.region = region
 
-        self.assertion = models.SamlAssertion(assertion)
+        self.assertion = SamlAssertion(assertion)
         self.writer = Credentials(cred_file)
 
         # Populated by self.assume_role()

--- a/nd_okta_auth/aws_saml.py
+++ b/nd_okta_auth/aws_saml.py
@@ -1,9 +1,22 @@
 # -*- coding: utf-8 -*-
 #
-# Credits: This code base was entirely stolen from
-# https://github.com/ThoughtWorksInc/aws_role_credentials. It continues to be
-# modified from the original code, but thanks a ton to the original writers at
-# Thought Works Inc.
+# Credits: This code was copied from
+# https://github.com/ThoughtWorksInc/aws_role_credentials
+#
+# Copyright (c) 2015, Peter Gillard-Moss
+# All rights reserved.
+
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import base64
 import xml.etree.ElementTree as ET

--- a/nd_okta_auth/aws_saml.py
+++ b/nd_okta_auth/aws_saml.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Credits: This code base was entirely stolen from
+# https://github.com/ThoughtWorksInc/aws_role_credentials. It continues to be
+# modified from the original code, but thanks a ton to the original writers at
+# Thought Works Inc.
+
+import base64
+import xml.etree.ElementTree as ET
+
+
+class SamlAssertion:
+
+    def __init__(self, assertion):
+        self.assertion = assertion
+
+    @staticmethod
+    def split_roles(roles):
+        return [(y.strip())
+                for y
+                in roles.text.split(',')]
+
+    @staticmethod
+    def sort_roles(roles):
+        return sorted(roles,
+                      key=lambda role: 'saml-provider' in role)
+
+    def roles(self):
+        attributes = ET.fromstring(self.assertion).getiterator(
+            '{urn:oasis:names:tc:SAML:2.0:assertion}Attribute')
+
+        name = 'https://aws.amazon.com/SAML/Attributes/Role'
+        roles_attributes = [x for x
+                            in attributes
+                            if x.get('Name') == name]
+
+        roles_values = [(x.getiterator(
+            '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'))
+                        for x
+                        in roles_attributes]
+
+        return [(dict(zip(['role', 'principle'],
+                          self.sort_roles(self.split_roles(x)))))
+                for x
+                in roles_values[0]]
+
+    def encode(self):
+        return base64.b64encode(self.assertion).decode()

--- a/nd_okta_auth/main.py
+++ b/nd_okta_auth/main.py
@@ -14,18 +14,25 @@
 #
 # Copyright 2017 Nextdoor.com, Inc
 
+from __future__ import unicode_literals
 import argparse
 import getpass
 import logging
 import sys
 import time
 import requests
+from builtins import input
 
 import rainbow_logging_handler
 
 from nd_okta_auth import okta
 from nd_okta_auth import aws
 from nd_okta_auth.metadata import __desc__, __version__
+
+
+def user_input(text):
+    '''Wraps input() making testing support of py2 and py3 easier'''
+    input(text)
 
 
 def setup_logging():
@@ -147,7 +154,7 @@ def main(argv):
         log.warning('MFA Requirement Detected - Enter your passcode here')
         verified = False
         while not verified:
-            passcode = raw_input('MFA Passcode: ')
+            passcode = user_input('MFA Passcode: ')
             verified = okta_client.validate_mfa(e.fid, e.state_token, passcode)
 
     # Once we're authenticated with an OktaSaml client object, we can use that

--- a/nd_okta_auth/okta.py
+++ b/nd_okta_auth/okta.py
@@ -6,24 +6,26 @@ Handles the initial Okta authentication - throws appropriate errors in the
 events of bad passwords, MFA requirements, etc.
 '''
 
+from __future__ import unicode_literals
 import base64
-import exceptions
 import logging
 import time
-
+import sys
 import bs4
 import requests
+if sys.version_info[0] < 3:  # Python 2
+    from exceptions import Exception
 
 log = logging.getLogger(__name__)
 
 BASE_URL = 'https://{organization}.okta.com'
 
 
-class BaseException(exceptions.Exception):
+class BaseException(Exception):
     '''Base Exception for Okta Auth'''
 
 
-class UnknownError(exceptions.Exception):
+class UnknownError(Exception):
     '''Some Expected Return Was Received'''
 
 
@@ -65,7 +67,7 @@ class Okta(object):
 
         # Validate the inputs are reasonably sane
         for input in (organization, username, password):
-            if (input == '' or input is None):
+            if input == '' or input is None:
                 raise EmptyInput()
 
         self.username = username
@@ -272,4 +274,4 @@ class OktaSaml(Okta):
                 msg=str(e.response.__dict__)))
             raise UnknownError()
 
-        return self.assertion(resp.text.decode('utf8'))
+        return self.assertion(resp.text)

--- a/nd_okta_auth/test/aws_saml_test.py
+++ b/nd_okta_auth/test/aws_saml_test.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Credits: This code base was entirely stolen from
-# https://github.com/ThoughtWorksInc/aws_role_credentials. It continues to be
-# modified from the original code, but thanks a ton to the original writers at
-# Thought Works Inc.
+# Credits: This code was copied from
+# https://github.com/ThoughtWorksInc/aws_role_credentials
+#
+# Copyright (c) 2015, Peter Gillard-Moss
+# All rights reserved.
+
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import sys
 from nd_okta_auth.aws_saml import SamlAssertion

--- a/nd_okta_auth/test/aws_saml_test.py
+++ b/nd_okta_auth/test/aws_saml_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Credits: This code base was entirely stolen from
+# https://github.com/ThoughtWorksInc/aws_role_credentials. It continues to be
+# modified from the original code, but thanks a ton to the original writers at
+# Thought Works Inc.
+
+import sys
+from nd_okta_auth.aws_saml import SamlAssertion
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+idp_arn = 'arn:aws:iam::1111:saml-provider/IDP'
+dev_arn = 'arn:aws:iam::1111:role/DevRole'
+qa_arn = 'arn:aws:iam::2222:role/QARole'
+idp2_arn = 'arn:aws:iam::2222:saml-provider/IDP'
+
+
+def saml_assertion(roles):
+    attribute_value = ('<saml2:AttributeValue xmlns:xs="http://www.w3.org/2001'
+                       '/XMLSchema" xmlns:xsi="http://www.w3.org/2001/'
+                       'XMLSchema-instance" xsi:type="xs:string">{0}'
+                       '</saml2:AttributeValue>')
+
+    roles_values = [(attribute_value.format(x)) for x in roles]
+
+    return ('<?xml version="1.0" encoding="UTF-8"?><saml2p:Response '
+            'xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" Version="2.0"'
+            ' xmlns:xs="http://www.w3.org/2001/XMLSchema"><saml2:Assertion '
+            'xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" '
+            'ID="id17773561036281221470153530" '
+            'IssueInstant="2015-11-06T10:48:25.399Z" Version="2.0" '
+            'xmlns:xs="http://www.w3.org/2001/XMLSchema"><saml2:'
+            'AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:'
+            'assertion"><saml2:Attribute Name="https://aws.amazon.com/SAML/'
+            'Attributes/Role" NameFormat="urn:oasis:names:tc:'
+            'SAML:2.0:attrname-format:uri">{0}</saml2:Attribute></'
+            'saml2:AttributeStatement></saml2:Assertion>'
+            '</saml2p:Response>').format("".join(roles_values))
+
+
+class TestSamlAssertion(unittest.TestCase):
+    def test_roles_are_extracted(self):
+        assertion = saml_assertion(['{},{}'.format(dev_arn, idp_arn)])
+
+        assert SamlAssertion(assertion).roles() == [{'role': dev_arn,
+                                                     'principle': idp_arn}]
+
+    def test_principle_can_be_first(self):
+        assertion = saml_assertion(['{},{}'.format(idp_arn, dev_arn)])
+
+        assert SamlAssertion(assertion).roles() == [{'role': dev_arn,
+                                                     'principle': idp_arn}]
+
+    def test_white_space_is_removed(self):
+        assertion = saml_assertion([' {},{} '.format(idp_arn, dev_arn)])
+
+        assert SamlAssertion(assertion).roles() == [{'role': dev_arn,
+                                                     'principle': idp_arn}]
+
+    def test_multiple_roles_are_returned(self):
+        assertion = saml_assertion(['{},{}'.format(dev_arn, idp_arn),
+                                    '{},{}'.format(qa_arn, idp2_arn)])
+
+        assert SamlAssertion(assertion).roles() == [{'role': dev_arn,
+                                                     'principle': idp_arn},
+                                                    {'role': qa_arn,
+                                                     'principle': idp2_arn}]
+
+    def test_assertion_is_encoded(self):
+        test_str = str.encode('test encoding')
+        assert SamlAssertion(test_str).encode() == 'dGVzdCBlbmNvZGluZw=='

--- a/nd_okta_auth/test/aws_test.py
+++ b/nd_okta_auth/test/aws_test.py
@@ -1,8 +1,12 @@
+from __future__ import unicode_literals
 import datetime
 import unittest
-import mock
-
+import sys
 from nd_okta_auth import aws
+if sys.version_info[0] < 3:  # Python 2
+    import mock
+else:
+    from unittest import mock
 
 
 class TestCredentials(unittest.TestCase):
@@ -26,15 +30,15 @@ class TestCredentials(unittest.TestCase):
             session_token='token')
 
         fake_parser.assert_has_calls([
-            mock.call.has_section(u'TestProfile'),
-            mock.call.add_section(u'TestProfile'),
-            mock.call.set(u'TestProfile', u'region', u'us-east-1'),
-            mock.call.set(u'TestProfile', u'aws_session_token', u'token'),
-            mock.call.set(u'TestProfile', u'aws_security_token', u'token'),
-            mock.call.set(u'TestProfile', u'aws_secret_access_key', u'secret'),
-            mock.call.set(u'TestProfile', u'output', u'json'),
-            mock.call.set(u'TestProfile', u'aws_access_key_id', u'key')
-        ])
+            mock.call.has_section('TestProfile'),
+            mock.call.add_section('TestProfile'),
+            mock.call.set('TestProfile', 'region', 'us-east-1'),
+            mock.call.set('TestProfile', 'aws_session_token', 'token'),
+            mock.call.set('TestProfile', 'aws_security_token', 'token'),
+            mock.call.set('TestProfile', 'aws_secret_access_key', 'secret'),
+            mock.call.set('TestProfile', 'output', 'json'),
+            mock.call.set('TestProfile', 'aws_access_key_id', 'key')
+        ], any_order=True)
 
     @mock.patch('nd_okta_auth.aws.os.chmod')
     @mock.patch('configparser.ConfigParser')
@@ -72,7 +76,7 @@ class TestCredentials(unittest.TestCase):
 
 class TestSesssion(unittest.TestCase):
 
-    @mock.patch('aws_role_credentials.models.SamlAssertion')
+    @mock.patch('nd_okta_auth.aws_saml.SamlAssertion')
     def setUp(self, mock_saml):
         self.fake_assertion = mock.MagicMock(name='FakeAssertion')
         mock_saml.return_value = self.fake_assertion

--- a/nd_okta_auth/test/okta_test.py
+++ b/nd_okta_auth/test/okta_test.py
@@ -1,75 +1,80 @@
+from __future__ import unicode_literals
 import unittest
-import mock
 import requests
-
+import sys
 from nd_okta_auth import okta
+if sys.version_info[0] < 3:  # Python 2
+    import mock
+else:
+    from unittest import mock
+
 
 # Successful response message from Okta when you have fully logged in
 SUCCESS_RESPONSE = {
-    u'status': u'SUCCESS',
-    u'expiresAt': u'2017-07-24T17:05:59.000Z',
-    u'_embedded': {
-        u'user': {
-            u'profile': {
-                u'locale': u'en',
-                u'lastName': u'Foo',
-                u'login': u'bob@foobar.com',
-                u'firstName': u'Bob', u'timeZone':
-                u'America/Los_Angeles'},
-            u'id': u'XXXIDXXX'
+    'status': 'SUCCESS',
+    'expiresAt': '2017-07-24T17:05:59.000Z',
+    '_embedded': {
+        'user': {
+            'profile': {
+                'locale': 'en',
+                'lastName': 'Foo',
+                'login': 'bob@foobar.com',
+                'firstName': 'Bob', 'timeZone':
+                'America/Los_Angeles'},
+            'id': 'XXXIDXXX'
         }
     },
-    u'sessionToken': u'XXXTOKENXXX'}
+    'sessionToken': 'XXXTOKENXXX'}
 
 # Miniaturized versions of the Okta response objects... they are too large to
 # really store here, and its not necessary.
 MFA_ENROLL_RESPONSE = {
-    u'status': u'MFA_ENROLL',
-    u'stateToken': 'token',
+    'status': 'MFA_ENROLL',
+    'stateToken': 'token',
 }
 MFA_CHALLENGE_RESPONSE_OKTA_VERIFY = {
-    u'status': u'MFA_REQUIRED',
-    u'_embedded': {
-        u'factors': [
+    'status': 'MFA_REQUIRED',
+    '_embedded': {
+        'factors': [
             {
-                u'factorType': 'push',
-                u'id': 'abcd',
+                'factorType': 'push',
+                'id': 'abcd',
             }
         ]
     },
-    u'stateToken': 'token',
+    'stateToken': 'token',
 }
 MFA_CHALLENGE_RESPONSE_PASSCODE = {
-    u'status': u'MFA_REQUIRED',
-    u'_embedded': {
-        u'factors': [
+    'status': 'MFA_REQUIRED',
+    '_embedded': {
+        'factors': [
             {
-                u'factorType': 'token:software:totp',
-                u'id': 'abcd',
+                'factorType': 'token:software:totp',
+                'id': 'abcd',
             }
         ]
     },
-    u'stateToken': 'token',
+    'stateToken': 'token',
 }
 MFA_WAITING_RESPONSE = {
-    u'status': u'MFA_CHALLENGE',
-    u'factorResult': u'WAITING',
-    u'_links': {
-        u'next': {
-            u'href': u'https://foobar.okta.com/api/v1/authn/factors/X/verify',
+    'status': 'MFA_CHALLENGE',
+    'factorResult': 'WAITING',
+    '_links': {
+        'next': {
+            'href': 'https://foobar.okta.com/api/v1/authn/factors/X/verify',
         }
     },
-    u'stateToken': 'token',
+    'stateToken': 'token',
 }
 MFA_REJECTED_RESPONSE = {
-    u'status': u'MFA_CHALLENGE',
-    u'factorResult': u'REJECTED',
-    u'_links': {
-        u'next': {
-            u'href': u'https://foobar.okta.com/api/v1/authn/factors/X/verify',
+    'status': 'MFA_CHALLENGE',
+    'factorResult': 'REJECTED',
+    '_links': {
+        'next': {
+            'href': 'https://foobar.okta.com/api/v1/authn/factors/X/verify',
         }
     },
-    u'stateToken': 'token',
+    'stateToken': 'token',
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ bs4>=0.0.1
 rainbow-logging-handler>=2.2.2
 requests>=2.10.0
 boto3>=1.4.0
-
-# TODO: Explain
-aws_role_credentials==0.6.3
+future==0.16.0
+configparser==3.5.0


### PR DESCRIPTION
Adds **Python 3.5.0+** support while maintaining support of **Python 2.7.1+**.

Due to the way Py3 handles string encoding SamlAssertion is copied over from aws_role_credentials with a minor change that allows it to work in both versions properly. This also removes the dependency on aws_role_credentials from this package.

Adding the magic comments for encoding and from `__future__ import unicode_literals `mean we can also clean up the u'' style for strings as everything will be unicode by default.

All tests pass in Python 2.7.1, 2.7.14, 3.5.0, and 3.6.3.

Additionally I've used `nd_okta_auth` to successfully authenticate with Okta on 2.7.1, 2.7.14, and 3.6.3 in manual testing.