### PR TITLE
Fix missed return in user_input() that breaks MFA input

### DIFF
--- a/nd_okta_auth/main.py
+++ b/nd_okta_auth/main.py
@@ -32,7 +32,7 @@ from nd_okta_auth.metadata import __desc__, __version__
 
 def user_input(text):
     '''Wraps input() making testing support of py2 and py3 easier'''
-    input(text)
+    return input(text)
 
 
 def setup_logging():


### PR DESCRIPTION
Found a bug I introduced when working on adding another feature; forgot to return from this function. This fixes the bug.