### PR TITLE
DX-1282 Suppress stack trace for expected exception

### DIFF
--- a/nd_okta_auth/main.py
+++ b/nd_okta_auth/main.py
@@ -15,7 +15,7 @@
 # Copyright 2017 Nextdoor.com, Inc
 import argparse
 from future.moves import sys
-from nd_okta_auth import auth
+from nd_okta_auth import auth, base_client
 from nd_okta_auth.metadata import __version__
 
 
@@ -113,7 +113,7 @@ def get_config_parser(argv):
 def entry_point():
     """Zero-argument entry point for use with setuptools/distribute."""
     config = get_config_parser(sys.argv)
-    raise SystemExit(
+    raise base_client.BaseException(
         auth.login(
             aws_profile=config.name,
             okta_appid=config.appid,
@@ -126,4 +126,7 @@ def entry_point():
 
 
 if __name__ == "__main__":
-    entry_point()
+    try:
+        entry_point()
+    except base_client.BaseException:
+        sys.exit(1)

--- a/nd_okta_auth/metadata.py
+++ b/nd_okta_auth/metadata.py
@@ -13,5 +13,5 @@
 # Copyright 2017 Nextdoor.com, Inc
 
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __desc__ = "Nextdoor Okta Auther"

--- a/nd_okta_auth/test/main_test.py
+++ b/nd_okta_auth/test/main_test.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import sys
 import unittest
 
-from nd_okta_auth import main
+from nd_okta_auth import main, base_client
 
 if sys.version_info[0] < 3:  # Python 2
     import mock
@@ -37,7 +37,7 @@ class MainTest(unittest.TestCase):
         fake_parser.reup = False
         config_mock.return_value = fake_parser
         # When
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(base_client.BaseException):
             main.entry_point()
         # Then
         auth_login.assert_called_with(


### PR DESCRIPTION
Since it is not covered by unit tests, manually verified the change with:
```
(venv) Zhiquns-MacBook-Pro:nd_okta_auth zhiqun$ python3 -m nd_okta_auth.main -a {hidden} -n eng -u zhiqun  -o nextdoor 
14:55:34   (INFO) Nextdoor Okta Auther v1.0.4
Password: 
14:55:37   (ERROR) Invalid Username (zhiqun) or Password
```