### PR TITLE
Add the ability to alias multiple profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ nd_okta_auth.egg-info
 build/
 htmlcov/
 venv
+.DS_Store

--- a/nd_okta_auth/auth.py
+++ b/nd_okta_auth/auth.py
@@ -32,6 +32,7 @@ def setup_logging():
 
 def login(
     aws_profile: str,
+    aws_profile_aliases: str,
     okta_appid: str,
     okta_org: str,
     username: str,
@@ -88,7 +89,10 @@ def login(
             assertion = okta_client.get_assertion(
                 appid=okta_appid, apptype="amazon_aws"
             )
-            session = aws.Session(assertion, profile=aws_profile)
+            session = aws.Session(
+                assertion, profile=aws_profile,
+                profile_aliases=aws_profile_aliases
+            )
 
             # If role_selection is set we're in a reup loop. Re-set the role on
             # the session to prevent the user being prompted for the role again

--- a/nd_okta_auth/main.py
+++ b/nd_okta_auth/main.py
@@ -105,6 +105,10 @@ def get_config_parser(argv):
     optional_args.add_argument(
         "-n", "--name", type=str, help="AWS Profile Name", default="default"
     )
+    optional_args.add_argument(
+        "-A", "--alias", type=str, default="",
+        help="Comma-separated list of additional profile names to write"
+    )
 
     config = arg_parser.parse_args(args=argv[1:])
     return config
@@ -116,6 +120,7 @@ def entry_point():
     try:
         auth.login(
             aws_profile=config.name,
+            aws_profile_aliases=config.alias,
             okta_appid=config.appid,
             okta_org=config.org,
             username=config.username,

--- a/nd_okta_auth/test/auth_test.py
+++ b/nd_okta_auth/test/auth_test.py
@@ -99,6 +99,7 @@ class AuthTest(unittest.TestCase):
 def _run_auth_login():
     login(
         aws_profile="eng",
+        aws_profile_aliases="",
         okta_appid="appid",
         okta_org="org",
         username="username",


### PR DESCRIPTION
**Use Case**

Consider an environment where there are multiple profile names, some of which are deprecated but still being used. Invocations of nd_okta_auth might reasonably look like

```bash
nd_okta_auth ... -n goodProfile
```

and 

```bash
nd_okta_auth ... -n deprecatedProfile
```

Both invocations use the same organization, user name, and app ID to assume the same role, but using different profile names in the AWS configuration.

**Proposed Change**

This PR adds support for an optional `--alias` flag, that accepts one or more comma-separated profile names to write in addition to the one written by `--name`. In this model, the two calls above can be combined into

```bash
nd_okta_auth ... -n goodProfile -A deprecatedProfile
```

Fore completeness, this is also accepted:

```bash
nd_okta_auth ... -n goodProfile -A deprecatedProfile,obsoleteProfile
```